### PR TITLE
Force payload to json to avoid undefined 'as_json'

### DIFF
--- a/lib/rollbar/delay/resque.rb
+++ b/lib/rollbar/delay/resque.rb
@@ -4,7 +4,7 @@ module Rollbar
   module Delay
     class Resque
       def self.call(payload)
-        new.call(payload)
+        new.call(payload.to_json)
       end
 
       def call(payload)


### PR DESCRIPTION
<NoMethodError: undefined method `as_json' for <Redis::Future [:sadd, "resque:queues", "high"]>:Redis::Future>
